### PR TITLE
fix gcc warning for fibc.c ,gcc (Debian 4.9.2-10) 4.9.2

### DIFF
--- a/module/intro_cython/fibonacci/fibc.c
+++ b/module/intro_cython/fibonacci/fibc.c
@@ -1,3 +1,5 @@
+#include <stdio.h>
+#include <stdlib.h>
 #include "fibc.h"
 
 int fibc(int n) {
@@ -18,4 +20,5 @@ int main (int argc, char *argv[])
     for (i = 0; i < atoi(argv[2]); ++i)
       result = fibc(atoi(argv[1]));
     printf("%d\n", result);
+    return 1;
 }


### PR DESCRIPTION
fix gcc warning for fibc.c ,gcc (Debian 4.9.2-10) 4.9.2

compiling by

```
python setup.py -q build_ext --inplace -f
```

will get

```
vagrant@debian-jessie:/tmp/hw1/fibonacci$ python setup.py -q build_ext --inplace -f
Compiling cfib.pyx because it changed.
Cythonizing cfib.pyx
fibc.c: In function ‘main’:
fibc.c:18:5: warning: implicit declaration of function ‘atoi’ [-Wimplicit-function-declaration]
     for (i = 0; i < atoi(argv[2]); ++i)
     ^
fibc.c:20:5: warning: implicit declaration of function ‘printf’ [-Wimplicit-function-declaration]
     printf("%d\n", result);
     ^
fibc.c:20:5: warning: incompatible implicit declaration of built-in function ‘printf’
fibc.c:21:1: warning: control reaches end of non-void function [-Wreturn-type]
 }
 ^
```

stdio.h for warning: implicit declaration of function ‘printf’ [-Wimplicit-function-declaration]
stdlib.h for warning: implicit declaration of function ‘atoi’ [-Wimplicit-function-declaration]
return 1 for warning: control reaches end of non-void function [-Wreturn-type]
